### PR TITLE
Submit Ch3 HW 2

### DIFF
--- a/Src/BootCamp.Chapter/Credentials.cs
+++ b/Src/BootCamp.Chapter/Credentials.cs
@@ -1,22 +1,81 @@
-﻿namespace BootCamp.Chapter
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace BootCamp.Chapter
 {
-    // TODO: make a struct and add validation and other needed methods (if needed)
-    public class Credentials
-    {
-        public string Username;
-        public string Password;
+	public readonly struct Credentials
+	{
+		public readonly string Username;
+		private readonly string Password;
 
-        public Credentials(string username, string password)
-        {
-            Username = username;
-            Password = password;
-        }
+		private Credentials(string username, string password, bool isEncoded) : this()
+		{
+			//Throw argument exception if username or password are null or blank
+			if (username == null || username.Equals("") || password == null || password.Equals(""))
+			{
+				throw new ArgumentException();
+			}
 
-        // TODO: Implement properly.
-        public static bool TryParse(string input, out Credentials credentials)
-        {
-            credentials = default;
-            return false;
-        }
-    }
+			Username = username;
+
+			if (isEncoded)
+			{
+				Password = password;
+			}
+			else//Encode it
+			{
+				Password = EncodePassword(password);
+			}
+		}
+		//Takes an uncoded username and password
+		public Credentials(string username, string password) : this(username, password, isEncoded: false)//Encode the password
+		{
+		}
+
+		public static bool TryParse(string input, out Credentials credentials)
+		{
+			//Input should only be 2 strings seperated by ,
+			string[] inputs = input.Split(',');
+			if (inputs.Length != 2)
+			{
+				credentials = default;
+				return false;
+			}
+
+			//Create new credentials
+			credentials = new Credentials(inputs[0], inputs[1], isEncoded: true);
+			
+			return true;
+		}
+		public override bool Equals(object obj)
+		{
+			//Return false if null or not Credentials
+			if (obj == null || !obj.GetType().Equals(typeof(Credentials)))
+			{
+				return false;
+			}
+
+			//Return false if username or password don't match
+			Credentials credObj = (Credentials)obj;
+			if (!credObj.Username.Equals(Username) || !credObj.Password.Equals(Password))
+			{
+				return false;
+			}
+			
+			return true;
+		}
+
+		public override string ToString()
+		{
+			return $"{Username},{Password}";
+		}
+
+		private string EncodePassword(string password)
+		{
+			byte[] passwordBytes = Encoding.Unicode.GetBytes(password, 0, password.Length);
+			return string.Join(" ", passwordBytes);
+		}
+	}
 }

--- a/Src/BootCamp.Chapter/CredentialsManager.cs
+++ b/Src/BootCamp.Chapter/CredentialsManager.cs
@@ -1,24 +1,92 @@
-﻿namespace BootCamp.Chapter
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace BootCamp.Chapter
 {
-    public class CredentialsManager
-    {
-        private readonly string _credentialsFile;
+	public class CredentialsManager
+	{
+		private string CredentialsFile { get; }
 
-        public CredentialsManager(string credentialsFile)
-        {
-            _credentialsFile = credentialsFile;
-        }
+		public CredentialsManager(string credentialsFile)
+		{
+			//Throw argument exception if string is null or empty
+			if (credentialsFile == null || credentialsFile.Equals(""))
+			{
+				throw new ArgumentException();
+			}
 
-        // TODO: load credentials and check for equality.
-        public bool Login(Credentials credentials)
-        {
-            return false;
-        }
+			CredentialsFile = credentialsFile;
+		}
 
-        // TODO: store credentials in credentials file.
-        public void Register(Credentials credentials)
-        {
+		public bool Login(Credentials credentials)
+		{
+			return ValidateLogin(CredentialsFile, credentials);
+		}
 
-        }
-    }
+		public void Register(Credentials credentials)
+		{
+			StoreCredentials(CredentialsFile, credentials);
+		}
+
+		private bool ValidateLogin(string filePath, Credentials credential)
+		{
+			//Get list of credentials from file
+			List<Credentials> credentials;
+			if (!TryGetCredentials(filePath, out credentials))
+			{
+				//Conversion failed
+				return false;
+			}
+
+			//Return if this instance is in the file
+			return credentials.Contains(credential);
+		}
+
+		private bool TryGetCredentials(string filePath, out List<Credentials> credentials)
+		{
+			//Read the file
+			string fileText;
+			using (StreamReader sr = new StreamReader(filePath))
+			{
+				fileText = sr.ReadToEnd();
+			}
+
+			//Parse lines
+			string[] entries = fileText.Split(Environment.NewLine);
+
+			//Fill the list
+			credentials = new List<Credentials>();
+			foreach (string entry in entries)
+			{
+				//Convert to Credentials and return false if any fail
+				Credentials credential;
+				if (!Credentials.TryParse(entry, out credential))
+				{
+					return false;
+				}
+
+				credentials.Add(credential);
+			}
+
+			return true;
+		}
+
+		private void StoreCredentials(string filePath, Credentials credentials)
+		{
+			//Check if file has any existing entries or not
+			bool hasEntries = File.ReadAllText(filePath).Length > 0;
+
+			//Open the file to write
+			using (StreamWriter sw = new StreamWriter(filePath, append: true))
+			{
+				//If there's already entries then add a newline before adding the next entry
+				if (hasEntries)
+				{
+					sw.Write(Environment.NewLine);
+				}
+				sw.Write(credentials.ToString());
+			}
+		}
+	}
 }

--- a/Src/BootCamp.Chapter/Program.cs
+++ b/Src/BootCamp.Chapter/Program.cs
@@ -1,10 +1,75 @@
-﻿namespace BootCamp.Chapter
-{
-    class Program
-    {
-        static void Main(string[] args)
-        {
+﻿using System;
+using System.IO;
 
-        }
-    }
+namespace BootCamp.Chapter
+{
+	class Program
+	{
+		const string FILE_PATH = @"HW.txt";
+
+		static void Main(string[] args)
+		{
+			//Create or overwrite example file
+			File.WriteAllText(FILE_PATH, "");
+
+			//Have user register credentials
+			UserInputsCredentials();
+
+			//Login
+			UserLogsIn();
+		}
+
+		public static void UserInputsCredentials()
+		{
+			CredentialsManager credentialsManager = new CredentialsManager(FILE_PATH);
+			Console.WriteLine("Register login:");
+
+			bool isRepeating = false;
+
+			do
+			{
+				//Register credentials
+				credentialsManager.Register(GetUserCredentials());
+
+				Console.Write("Would you like to register another login? (y/n): ");
+				isRepeating = Console.ReadLine().ToLower().Equals("y");
+			} while (isRepeating);
+		}
+
+		public static void UserLogsIn()
+		{
+			CredentialsManager credentialsManager = new CredentialsManager(FILE_PATH);
+
+			//Login
+			Console.WriteLine("Login:");
+
+			bool isRepeating = false;
+
+			do
+			{
+				if (credentialsManager.Login(GetUserCredentials()))
+				{
+					Console.WriteLine("Logged in");
+				}
+				else
+				{
+					Console.WriteLine("Log in failed");
+				}
+
+				Console.Write("Would you like to try logging in again? (y/n): ");
+				isRepeating = Console.ReadLine().ToLower().Equals("y");
+			} while (isRepeating);
+		}
+
+		public static Credentials GetUserCredentials()
+		{
+			//Get name and password
+			Console.Write("Name: ");
+			string name = Console.ReadLine();
+			Console.Write("Password: ");
+			string password = Console.ReadLine();
+
+			return new Credentials(name, password);
+		}
+	}
 }


### PR DESCRIPTION
Note: CredentialsManagerTests.Login_When_Credentials_File_Contains_The_Credentials_Returns_True and CredentialsManagerTests.Register_Given_Valid_FilledFile_Appends_Comma_Separated_Credentials are using the same file: "Input/Files/TomTom123Credentials.txt". When running all tests at the same time, this file isn't reset between the 2 tests so if CredentialsManager.Register(Credentials) from Register_Given_Valid_FilledFile_Appends_Comma_Separated_Credentials is incorrectly editting the file (such as adding a blank line to the file), then Login_When_Credentials_File_Contains_The_Credentials_Returns_True will fail because CredentialsManager.Login(Credentials) (because it's not expecting a blank line in the file). In this case there's no issue with the functions being tested in Login_When_Credentials_File_Contains_The_Credentials_Returns_True as it passes when ran by itself, but it incorrectly fails when ran with all tests.

-Changed Credentials from a class to a struct.
-Created a private Credentials constructor to choose whether to encode the password or not. Default construction always encodes and internal methods, like TryParse(), don't encode. -Implemented Credentials.TryParse().
-Overrode Credentials.Equals() and Credentials.ToString().

-Implemented CredentialsManager.Login() and CredentialsManager.Register().

-Created example program to register logins from the user, store them in a txt file, have the user try to login, compare against the logins stored in the txt file, and display if the login was correct or not.