### PR TITLE
Submit CH3 HW 12

### DIFF
--- a/Src/BootCamp.Chapter/Address.cs
+++ b/Src/BootCamp.Chapter/Address.cs
@@ -4,21 +4,71 @@ using System.Text;
 
 namespace BootCamp.Chapter
 {
-    public class Address
-    {
-        public string Recipient { get; }
-        public string Street { get; }
+	public class Address
+	{
+		public string Recipient { get; }
+		public string Street { get; }
+		public string Town { get; }
+		public string County { get; }
+		public string PostalCode { get; }
+		public string Country { get; }
+		public string HouseNumber { get; }
 
-        public Address(string recipient, string street, string town, string county, string postalCode, string country, string houseNumber = "")
-        {
-            Recipient = recipient;
-            Street = street;
-        }
+		public Address(string recipient, string street, string town, string county, string postalCode, string country, string houseNumber = "")
+		{
+			Recipient = recipient;
+			Street = street;
+			Town = town;
+			County = county;
+			PostalCode = postalCode;
+			Country = country;
+			HouseNumber = houseNumber;
+		}
 
-        public static bool TryParse(string addressString, out Address address)
-        {
-            address = default;
-            return false;
-        }
-    }
+		public static bool TryParse(string addressString, out Address address)
+		{
+			address = default;
+
+			//Split string by lines
+			string[] addressFields = addressString.Split(Environment.NewLine);
+			//Return false if there aren't 7 lines
+			if (addressFields.Length != 7) return false;
+			//Setup values
+			string recipient = addressFields[0];
+			//BuildingName = addressFields[2]?//houseNumber isn't defined in the HW and this field never shows a number.
+			string street = addressFields[1];//Unit Test says this is the street, but HW website says it's the buildingName
+			string town = addressFields[3];
+			string county = addressFields[4];
+			string postalCode = addressFields[5];
+			string country = addressFields[6];
+
+			//Create new Address object
+			address = new Address(recipient, street, town, county, postalCode, country);
+			return true;
+		}
+
+		public static bool operator ==(Address leftAddress, Address rightAddress)
+		{
+			return leftAddress.Recipient.Equals(rightAddress.Recipient) &&
+				leftAddress.Street.Equals(rightAddress.Street) &&
+				leftAddress.Town.Equals(rightAddress.Town) &&
+				leftAddress.County.Equals(rightAddress.County) &&
+				leftAddress.PostalCode.Equals(rightAddress.PostalCode) &&
+				leftAddress.Country.Equals(rightAddress.Country) &&
+				leftAddress.HouseNumber.Equals(rightAddress.HouseNumber);
+		}
+		public static bool operator !=(Address leftAddress, Address rightAddress)
+		{
+			return !(leftAddress == rightAddress);
+		}
+		public override bool Equals(object obj)
+		{
+			return this == (Address)obj;
+		}
+
+		public override int GetHashCode()
+		{
+			return HashCode.Combine(Recipient, Street, Town, County, PostalCode, Country, HouseNumber);
+		}
+	}
 }

--- a/Src/BootCamp.Chapter/BootCamp.Chapter.csproj
+++ b/Src/BootCamp.Chapter/BootCamp.Chapter.csproj
@@ -1,8 +1,14 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Update="Addresses.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/Src/BootCamp.Chapter/Program.cs
+++ b/Src/BootCamp.Chapter/Program.cs
@@ -1,12 +1,60 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 
 namespace BootCamp.Chapter
 {
-    class Program
-    {
-        static void Main(string[] args)
-        {
+	class Program
+	{
+		private static readonly string FILE_PATH = "Addresses.txt";
 
-        }
-    }
+		static void Main(string[] args)
+		{
+			//Read Address file
+			string fileText = File.ReadAllText(FILE_PATH);
+			//Split into each address entry
+			//Each address entry is seperated by a new line (1st newline is the end of the entry, 2nd newline is the line between entries)
+			string[] addressTexts = fileText.Split(Environment.NewLine + Environment.NewLine);
+			//Parse into address objects
+			List<Address> addresses = new List<Address>();
+			foreach (string addressText in addressTexts)
+			{
+				Address address;
+				bool isAddress = Address.TryParse(addressText, out address);
+				if (isAddress)
+				{
+					addresses.Add(address);
+				}
+			}
+
+			//Get duplicate addresses
+			var dupAddresses = from address in addresses
+							   group address by address into addressGroup
+							   select new
+							   {
+								   DuplicateAddress = addressGroup.Key,
+								   DuplicateCount = addressGroup.Count()
+							   };
+			//Get total count per postal code
+			var postalGroupDups = from address in dupAddresses
+								  group address by address.DuplicateAddress.PostalCode into postalGroup
+								  select new
+								  {
+									  PostalCode = postalGroup.Key,
+									  DupCount = postalGroup.Sum(p => p.DuplicateCount)
+								  };
+			//Get highest dup count
+			int biggestDupCount = postalGroupDups.Max(p => p.DupCount);
+			//Get all postal codes with highest dup count (if more than 1)
+			var biggestDupCountPostals = from postalCode in postalGroupDups
+										 where postalCode.DupCount == biggestDupCount
+										 select postalCode.PostalCode;
+			string resultPostals = String.Join(", ", biggestDupCountPostals);
+
+			//Write results to console
+			Console.WriteLine($"Postal code(s) with the most duplicate addresses: {resultPostals}");
+			Console.ReadLine();
+		}
+	}
 }

--- a/Tests/BootCamp.Chapter.Tests/AddressTests.cs
+++ b/Tests/BootCamp.Chapter.Tests/AddressTests.cs
@@ -14,7 +14,7 @@ namespace BootCamp.Chapter.Tests
             var address1 = new Address("asd6", "asd1", "aa2", "aa3", "aa4", "aa5");
             var address2 = new Address("asd6", "asd1", "aa2", "aa3", "aa4", "aa5");
 
-            var areEqual = address2 == address2;
+            var areEqual = address1 == address2;
 
             areEqual.Should().BeTrue();
         }
@@ -36,7 +36,7 @@ namespace BootCamp.Chapter.Tests
             var address1 = new Address("asd6", "asd1", "aa2", "aa3", "aa4", "aa5");
             var address2 = new Address("asd0", "asd1", "aa2", "aa3", "aa4", "aa5");
 
-            var areEqual = address2 == address2;
+            var areEqual = address1 == address2;
 
             areEqual.Should().BeFalse();
         }


### PR DESCRIPTION
Tests/AddressTests:
Address1_EqualityOperator_On_Address2_When_Both_Have_Same_Values_Returns_True and Address1_EqualityOperator_On_Address2_When_Both_Have_Different_Values_Returns_False are comparing "address2 == address2". Changed to "address1 == address2" to match methods' naming.
--------------------
-Updated Addresses.txt's "Copy to Output Directory" property to be "Copy if newer" as the file wasn't showing up during debugging.
-Implemented Address.TryParse().
-Implemented Address's == and != overloads.
-Implemented Address's Equals() and GetHashCode() to utilize the new == overload within LINQ.
-Updated Main() to read the given text file, find postal codes with the most duplicate address entries, and then display the results to the console.